### PR TITLE
fix shiboken import with qt6

### DIFF
--- a/MeshRemodelCmd.py
+++ b/MeshRemodelCmd.py
@@ -38,7 +38,10 @@ except:
 import Draft, DraftGeomUtils, DraftVecUtils, Mesh, MeshPart
 import time
 import numpy as np
-import shiboken2 as shiboken
+try:
+    import shiboken6 as shiboken
+except:
+    import shiboken2 as shiboken
 
 
 if FreeCAD.GuiUp:


### PR DESCRIPTION
On Arch Linux, the FreeCAD package pulls in pyside6 rather than pyside5. In pyside6, shiboken is available under the `shiboken6` package rather than `shiboken2`, so this WB fails to load.

With this PR, we try importing from `shiboken6`, and fall back to `shiboken2` if it's not available.